### PR TITLE
Bump to 1.3.1, Upgrade estafette-ci-api

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -10,9 +10,9 @@ version:
   semver:
     major: 1
     minor: 3
-    patch: 0
+    patch: 1
     labelTemplate: '{{branch}}-{{auto}}'
-    releaseBranch: 1.3.0
+    releaseBranch: 1.3.1
 
 stages:
   lint-and-package:

--- a/helm/estafette-ci/charts/estafette-ci-api/Chart.yaml
+++ b/helm/estafette-ci/charts/estafette-ci-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2033
+version: 1.1.2035
 
 home: https://helm.estafette.io
 icon: https://helm.estafette.io/icon.png


### PR DESCRIPTION
Fixes BuildControl and Release pointer nil check