### PR TITLE
update cockroachdb chart version

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -10,9 +10,9 @@ version:
   semver:
     major: 1
     minor: 3
-    patch: 1
+    patch: 2
     labelTemplate: '{{branch}}-{{auto}}'
-    releaseBranch: 1.3.1
+    releaseBranch: 1.3.2
 
 stages:
   lint-and-package:

--- a/helm/estafette-ci/Chart.yaml
+++ b/helm/estafette-ci/Chart.yaml
@@ -47,7 +47,7 @@ dependencies:
   condition: web.enabled
 
 - name: cockroachdb
-  version: 8.1.1
+  version: 8.1.8
   repository: https://charts.cockroachdb.com/
   alias: db
   condition: db.enabled


### PR DESCRIPTION
## WHAT
- Update cockroachdb chart version

## WHY:
- cockroachdb Helm chart version 8.0.1 doesn't support new version batch/v1 and policy/v1 k8s api versions

I got this error when I tried to install latest version 
```Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "estafette-ci-db-budget" namespace: "estafette-ci" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "estafette-ci-db-rotate-self-signer" namespace: "estafette-ci" from "": no matches for kind "CronJob" in version "batch/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "estafette-ci-db-rotate-self-signer-client" namespace: "estafette-ci" from "": no matches for kind "CronJob" in version "batch/v1beta1"
ensure CRDs are installed first]
```