### PR TITLE
remove capabilities check as it is not reliable and based on Kuberntes client

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -10,9 +10,9 @@ version:
   semver:
     major: 1
     minor: 5
-    patch: 5
+    patch: 6
     labelTemplate: '{{branch}}-{{auto}}'
-    releaseBranch: 1.5.5
+    releaseBranch: 1.5.6
 
 stages:
   lint-and-package:

--- a/helm/estafette-ci/charts/estafette-ci-api/templates/poddisruptionbudget.yaml
+++ b/helm/estafette-ci/charts/estafette-ci-api/templates/poddisruptionbudget.yaml
@@ -1,8 +1,5 @@
 {{- if $.Values.pdb.enabled }}
-{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else -}}
-apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/helm/estafette-ci/charts/estafette-ci-web/templates/poddisruptionbudget.yaml
+++ b/helm/estafette-ci/charts/estafette-ci-web/templates/poddisruptionbudget.yaml
@@ -1,8 +1,5 @@
 {{- if $.Values.pdb.enabled }}
-{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else -}}
-apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
https://github.com/helm/helm/issues/11809

```Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "estafette-ci-api" namespace: "" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
ensure CRDs are installed first, resource mapping not found for name: "estafette-ci-web" namespace: "" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
ensure CRDs are installed first]
Installation failed, showing logs...